### PR TITLE
Add multi-account connection endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # XamOps-Dashboard
+
+This project provides a Spring Boot based dashboard for visualising data across multiple AWS accounts.
+
+### Connecting Accounts
+
+1. Use `POST /api/account-manager/generate-stack-url` with an account name to obtain a CloudFormation quick create URL.
+2. Launch the stack in the target AWS account. It creates a cross‑account role.
+3. Call `POST /api/account-manager/verify-stack` with the role ARN and external ID to finalise the connection.
+4. Connected accounts can be listed with `GET /api/account-manager/accounts`.

--- a/cloud/src/main/java/com/xammer/cloud/controller/AccountManagerController.java
+++ b/cloud/src/main/java/com/xammer/cloud/controller/AccountManagerController.java
@@ -1,14 +1,19 @@
 package com.xammer.cloud.controller;
 
 import com.xammer.cloud.dto.AccountCreationRequestDto;
+import com.xammer.cloud.dto.VerifyAccountRequest;
+import com.xammer.cloud.dto.AccountDto;
+import com.xammer.cloud.domain.CloudAccount;
 import com.xammer.cloud.service.AwsDataService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -29,5 +34,27 @@ public class AccountManagerController {
         } catch (Exception e) {
             return ResponseEntity.badRequest().body(Map.of("error", "Could not generate CloudFormation URL", "message", e.getMessage()));
         }
+    }
+
+    @PostMapping("/verify-stack")
+    public ResponseEntity<Map<String, String>> verifyStack(@RequestBody VerifyAccountRequest request) {
+        try {
+            CloudAccount account = awsDataService.verifyAccount(request.getAccountName(), request.getRoleArn(), request.getExternalId());
+            return ResponseEntity.ok(Map.of("status", account.getStatus()));
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Verification failed", "message", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/accounts")
+    public List<AccountDto> getAccounts() {
+        return awsDataService.getAccounts().stream().map(a -> new AccountDto(
+                a.getAccountName(),
+                a.getAwsAccountId(),
+                a.getAccessType(),
+                a.getRoleArn() != null ? "Cross-account role" : "-",
+                a.getStatus(),
+                a.getRoleArn()
+        )).toList();
     }
 }

--- a/cloud/src/main/java/com/xammer/cloud/repository/CloudAccountRepository.java
+++ b/cloud/src/main/java/com/xammer/cloud/repository/CloudAccountRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CloudAccountRepository extends JpaRepository<CloudAccount, Long> {
+    java.util.Optional<CloudAccount> findByExternalId(String externalId);
 }


### PR DESCRIPTION
## Summary
- document how to connect additional AWS accounts
- allow account verification and listing
- add repository method for fetching accounts by external ID
- verify and store role ARN using STS assume role

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e2ac922c8326973afb37e56df03a