### PR TITLE
Remove duplicate Kubernetes imports

### DIFF
--- a/cloud/src/main/java/com/xammer/cloud/service/AwsDataService.java
+++ b/cloud/src/main/java/com/xammer/cloud/service/AwsDataService.java
@@ -176,12 +176,8 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sts.StsClient;
 
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.Configuration;
-import io.kubernetes.client.openapi.apis.CoreV1Api;
-import io.kubernetes.client.util.ClientBuilder;
 import io.kubernetes.client.util.KubeConfig;
-import software.amazon.awssdk.services.eks.model.Cluster;
 
 @Service
 public class AwsDataService {


### PR DESCRIPTION
## Summary
- clean up duplicate imports in AwsDataService

## Testing
- `mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6874e794707883268f0c7178ae66273e